### PR TITLE
Remove extra print statement on watcher stop

### DIFF
--- a/src/garden_watcher/core.clj
+++ b/src/garden_watcher/core.clj
@@ -82,7 +82,6 @@ syms with a :garden metadata key, and compiles them to CSS."
         (assoc this :garden-watcher-hawk (hawk/watch! [{:paths paths
                                                         :handler handler}])))))
   (stop [this]
-    (println "Garden: stopped watching namespaces.")
     (if-let [hawk (:garden-watcher-hawk this)]
       (do
         (hawk/stop! hawk)


### PR DESCRIPTION
Having it print that it's stopping twice is fairly confusing; remove the extra print statement.