### PR TITLE
Support to path watches and master namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ metadata key in the given namespaces to a CSS file.
   (component/system-map
    :figwheel-system (fw-sys/figwheel-system (fw-conf/fetch-config))
    :css-watcher (fw-sys/css-watcher {:watch-paths ["resources/public/css"]})
-   :garden-watcher (new-garden-watcher '[sesame.styles]))) ;; <------
+   :garden-watcher (new-garden-watcher {:watch ['sesame.styles]}))) ;; <------
 ```
 
 The above will generate `resources/public/css/main.css`, and recreate it
@@ -114,7 +114,7 @@ garden-watcher also includes a "main" entry point to make it easy to invoke
 this as a build step.
 
 ```
-lein run -m garden-watcher.main sesame.styles
+lein run -m garden-watcher.main --namespace sesame.styles
 ```
 
 E.g. say you're building an uberjar containing compiled ClojureScript and CSS.
@@ -129,7 +129,7 @@ E.g. say you're building an uberjar containing compiled ClojureScript and CSS.
              :uberjar
              {:prep-tasks ["compile"
                            ["cljsbuild" "once" "min"]
-                           ["run" "-m" "garden-watcher.main" "sesame.styles"]]
+                           ["run" "-m" "garden-watcher.main" "--namespace" "sesame.styles"]]
               :omit-source true
               :aot :all}})
 ```

--- a/project.clj
+++ b/project.clj
@@ -6,5 +6,6 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.stuartsierra/component "0.3.1"]
                  [org.clojure/java.classpath "0.2.3"]
+                 [org.clojure/tools.cli "0.3.5"]
                  [hawk "0.2.11"]
                  [garden "1.3.2"]])

--- a/src/garden_watcher/core.clj
+++ b/src/garden_watcher/core.clj
@@ -9,7 +9,7 @@
            java.nio.file.Paths
            java.nio.file.Files))
 
-(defn- ns-file-name
+(defn- ns->file-name
   "Copied from clojure.tools.namespace.move because it's private there."
   [sym]
   (str (-> (name sym)
@@ -17,36 +17,51 @@
            (str/replace "." File/separator))
        ".clj"))
 
+(defn- file-name->ns
+  "Converts a relative file name (string) into a namespace."
+  [file]
+  (-> file
+      (str/replace ".clj" "")
+      (str/replace File/separator ".")
+      (str/replace "_" "-")
+      symbol))
+
+(defn- sanitize-classpath
+  "Strips any classpath from the file path."
+  [file-path]
+  (reduce #(str/replace %1 (re-pattern (str "^" (.getPath %2))) "")
+          file-path
+          (cp/classpath-directories)))
+
+(defn- sanitize-leading-sep
+  "Strips any leading separator from a file path."
+  [file-path]
+  (str/replace file-path (re-pattern (str "^" File/separator)) ""))
+
+(defn- file-path->relative-path
+  "Converts a full file path to a relative file path."
+  [file-path]
+  (-> file-path
+      sanitize-classpath
+      sanitize-leading-sep))
+
 (defn- file-on-classpath
   "Given a relative path to a source file, find it on the classpath, returning a
-fully qualified java.io.File "
+  fully qualified java.io.File "
   [path]
   (->> (cp/classpath)
        (map #(io/file % path))
        (filter #(.exists %))
        first))
 
-(defn- select-ns-path
-  "Given a list of namespace names (symbols) and a path (string), transforms the
-path so it's relative to the classpath"
-  [namespaces file]
-  (let [ns-paths (map ns-file-name namespaces)]
-    (first (filter #(.endsWith file %) ns-paths))))
-
-(defn- file->ns
-  "Given a list of namespace names (symbols) and a path (string), return the
-namespace name that corresponds with the path name"
-  [namespaces path]
-  (first (filter #(.endsWith path (ns-file-name %)) namespaces)))
-
 (defn- reload-and-compile!
   "Reload the given path, then find all vars with a :garden metadata in the
-corresponding namespace, and compile those to CSS. The target path is either
-defined in the :garden metadata as :output-to, or it's derived from the var
-name as resources/public/css/<name>.css"
-  [namespaces path]
-  (when-let [ns (file->ns namespaces path)]
-    (require ns :reload)
+  corresponding namespace, and compile those to CSS. The target path is either
+  defined in the :garden metadata as :output-to, or it's derived from the var
+  name as resources/public/css/<name>.css"
+  [path]
+  (let [ns (-> path file-path->relative-path file-name->ns)]
+    (require ns :reload-all)
     (doseq [[sym var] (ns-publics ns)]
       (when-let [garden-meta (-> var meta :garden)]
         (let [garden-meta (if (map? garden-meta) garden-meta {})]
@@ -55,32 +70,59 @@ name as resources/public/css/<name>.css"
             (io/make-parents target)
             (css (assoc garden-meta :output-to target) @var)))))))
 
-(defn- garden-reloader-handler [namespaces]
+(defn- garden-reloader-handler [master-ns]
   (fn [_ctx event]
     (when (= (:kind event) :modify)
-      (when-let [ns-path (select-ns-path namespaces (str (:file event)))]
-        (reload-and-compile! namespaces ns-path)))))
+      (reload-and-compile! (str (:file event)))
+      (when master-ns
+        (when-let [master-file (-> master-ns ns->file-name file-on-classpath)]
+          (reload-and-compile! (.getPath master-file)))))))
+
+(defn- watch-path [entry]
+  (cond
+    (symbol? entry) (-> entry ns->file-name file-on-classpath)
+    (string? entry) (io/as-file (str (System/getProperty "user.dir")
+                                     File/separator
+                                     entry))))
+
+(defn master-ns-and-watch->namespaces
+  "Given a master namespace and a watch list, returns a list of namespaces"
+  [master-ns watch]
+  (->> watch
+       (map watch-path)
+       (#(if master-ns (conj % (-> master-ns ns->file-name file-on-classpath)) %))
+       (filter #(.isFile %))))
+
+(defn compile-garden-paths
+  "Given a list of paths, reloads the each, finds all syms with a :garden metadata
+  key, and compiles them to CSS."
+  [paths]
+  (run! #(reload-and-compile! %)
+        paths))
 
 (defn compile-garden-namespaces
-  "Given a list of namespaces (seq of symbol), reloads the namespaces, finds all
-syms with a :garden metadata key, and compiles them to CSS."
+  "Given a list of paths, reloads the each, finds all syms with a :garden metadata
+  key, and compiles them to CSS."
   [namespaces]
-  (run! #(reload-and-compile! namespaces %)
-        (map ns-file-name namespaces)))
+  (compile-garden-paths (map watch-path namespaces)))
 
-(defrecord GardenWatcherComponent [namespaces]
+(defrecord GardenWatcherComponent [master-ns watch]
   component/Lifecycle
   (start [this]
     (if (:garden-watcher-hawk this)
       (do
         (println "Garden: watcher already running.")
         this)
-      (let [paths (map (comp file-on-classpath ns-file-name) namespaces)
-            handler (garden-reloader-handler namespaces)]
-        (compile-garden-namespaces namespaces)
+      (let [paths (map #(-> % watch-path .getPath) watch)
+            handler (garden-reloader-handler master-ns)]
+
+        (compile-garden-paths (master-ns-and-watch->namespaces master-ns watch))
         (println "Garden: watching" (str/join ", " paths))
-        (assoc this :garden-watcher-hawk (hawk/watch! [{:paths paths
-                                                        :handler handler}])))))
+
+        (let [watcher (hawk/watch! [{:paths (vec paths)
+                                     :handler handler}])]
+          (assoc this :garden-watcher-hawk watcher)))))
+  
   (stop [this]
     (if-let [hawk (:garden-watcher-hawk this)]
       (do
@@ -92,7 +134,13 @@ syms with a :garden metadata key, and compiles them to CSS."
         this))))
 
 (defn new-garden-watcher
-  "Create a new Sierra Component that watches the given namespaces for changes,
-and upon change compiles any symbols with a :garden metadata key to CSS."
- [namespaces]
-  (->GardenWatcherComponent namespaces))
+  "Create a new Sierra Component that watches the given namespaces and/or paths for changes,
+  and upon change compiles any symbols with a :garden metadata key to CSS.
+
+  Watchers are set using the `:watch` keyword and specifying namespaces (as symbols) or paths
+  (as strings).
+
+  Alternatevely, a `:master-ns` can be specified. This is a symbol pointing to a master namespace
+  that needs to be regenerated shall any change occur."
+  [{:keys [master-ns watch]}]
+  (->GardenWatcherComponent master-ns watch))

--- a/src/garden_watcher/main.clj
+++ b/src/garden_watcher/main.clj
@@ -1,6 +1,21 @@
 (ns garden-watcher.main
   (:gen-class)
-  (:require [garden-watcher.core :refer [compile-garden-namespaces]]))
+  (:require [garden-watcher.core :refer [compile-garden-namespaces]]
+            [clojure.tools.cli :refer [parse-opts]]))
+
+(def ^:private cli-options
+  ;; An option with a required argument
+  [["-n" "--namespace NAMESPACE" "Namespace (can be specified multiple times)"
+    :parse-fn #(symbol %)
+    :assoc-fn (fn [m k v] (println m k v)
+                (let [coll (or (:namespaces m) [])]
+                  (assoc m :namespaces (conj coll v))))]
+   ;; A boolean option defaulting to nil
+   ["-h" "--help"]])
 
 (defn -main [& args]
-  (compile-garden-namespaces (map symbol args)))
+  (let [parsed-opts (parse-opts args cli-options)]
+    (if-let [help (-> parsed-opts :options :help)]
+      (println (str "Syntax: lein run -m garden-watcher.main -n <namespace>\n\nOptions:\n\n"
+                    (:summary parsed-opts)))
+      (compile-garden-namespaces (-> parsed-opts :options :namespaces)))))


### PR DESCRIPTION
Here are the motivations:

1) Path watches

In some projects, whole directories may contain snipets of CSS code.
In these cases, adding each namespace to the watching list can be a
hassle. Therefore, this proposal allows users to specify paths on the
watch list alongside namespaces

2) Master namespace

In some projects, a change on a file representing a CSS component
dowstream may require a "master namespace" to be recompiled. This
proposal makes this possible.

How it works:

The interface for `new-garden-watcher` is now a map that takes two
keywords a `:watch` (mandatory) and a `:master-ns`.

`:watch` is the same vector of the previous version but now it also
accepts paths. Paths are differentiated from namespaces by being
represented in strings (instead of symbols for namespaces).

The optional `:master-ns` takes a namespace name in a symbol. This
namespace will allways be recompiled shall anything change.

The interface for `garden-watcher.main` also changed. Now a flag `-n`
or `--namespace` can be used to specify namespaces. Paths are a
possible future extension.