### PR TITLE
Update java.classpath to 0.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,6 @@
             :url "https://www.mozilla.org/en-US/MPL/2.0/"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.stuartsierra/component "0.3.1"]
-                 [org.clojure/java.classpath "0.2.3"]
+                 [org.clojure/java.classpath "0.3.0"]
                  [hawk "0.2.11"]
                  [garden "1.3.2"]])


### PR DESCRIPTION
Classpath was returning an empty list with jdk 1.9+ because of
a known issue: https://dev.clojure.org/jira/browse/CLASSPATH-8.
Version 0.3.0 fixes this issue.