### PR TITLE
Add optional argument to `new-garden-watcher` to pass `hawk` options map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
 
 ## Changed
 
+# 1.0.37 (2021-09-10 / 336d78a)
+
+## Added
+
+- Support for `hawk` options
+
+## Changed
+
+- Make `new-garden-watcher` function accept optional argument with `hawk` options.
+  Example of using `hawk` options can be found in [Polling Watches](https://github.com/wkf/hawk#polling-watches).
+
 # 1.0.36 (2021-01-14 / 4628d5b)
 
 ## Changed

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ component directly.
 Use `garden-watcher.core/new-garden-watcher` to create the component, passing it
 a vector of namespace names. Once started this will watch and compile each var
 with a `:garden` metadata key in the given namespaces to a CSS file.
+Also, [hawk](https://github.com/wkf/hawk) options map can be passed as a second argument.
 
 ``` clojure
 (ns user


### PR DESCRIPTION
Currently `(hawk/watch! ...)` call is hardcoded with no ability to pass any options.
Hawk uses a separate implementation of WatcherService for Mac OS. 
This particular implementation doesn’t work well with the latest versions of the OS (Big Sur), due to some JNA conflict.
So, the main reason for this changes is to be able to supply `hawk` options to fallback from native watcher implementation to java based.